### PR TITLE
[MI-1827]: Removed Mattermost logo from cards

### DIFF
--- a/tests-e2e/cypress/support/api/cloud_default_config.json
+++ b/tests-e2e/cypress/support/api/cloud_default_config.json
@@ -34,7 +34,7 @@
         "CollapsedThreads": "default_off"
     },
     "TeamSettings": {
-        "SiteName": "Mattermost",
+        "SiteName": "Wellsite",
         "MaxUsersPerTeam": 2000,
         "EnableUserCreation": true,
         "EnableOpenServer": true,

--- a/tests-e2e/cypress/support/api/on_prem_default_config.json
+++ b/tests-e2e/cypress/support/api/on_prem_default_config.json
@@ -88,7 +88,7 @@
         "CollapsedThreads": "default_off"
     },
     "TeamSettings": {
-        "SiteName": "Mattermost",
+        "SiteName": "Wellsite",
         "MaxUsersPerTeam": 2000,
         "EnableTeamCreation": true,
         "EnableUserCreation": true,

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -26,7 +26,6 @@
   "15jbT0": "Add more to your timeline",
   "1I48bs": "Retrospective template",
   "1MQ3XZ": "{numActiveRuns, plural, =0 {no active runs} =1 {# active run} other {# active runs}}",
-  "1QosTr": "Used by",
   "1ikfp3": "If you delete this metric, the values for it will not be collected for any future runs.",
   "2/2yg+": "Add",
   "2563nT": "Confirm finish run",

--- a/webapp/src/components/error_page.tsx
+++ b/webapp/src/components/error_page.tsx
@@ -27,7 +27,7 @@ const ErrorPage = () => {
     let title: React.ReactNode = 'Page not found';
     let message: React.ReactNode = 'The page you were trying to reach does not exist.';
     let returnTo = '/';
-    let returnToMsg: React.ReactNode = 'Back to Mattermost';
+    let returnToMsg: React.ReactNode = 'Back to Wellsite';
 
     switch (params.type) {
     case ErrorPageTypes.PLAYBOOK_RUNS:

--- a/webapp/src/components/templates/template_item.tsx
+++ b/webapp/src/components/templates/template_item.tsx
@@ -51,7 +51,7 @@ const Item = styled.div`
     border-radius: 8px;
     box-sizing: border-box;
     box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
-    aspect-ratio: 284 / 300;
+    aspect-ratio: 284 / 240;
     max-width: 360px;
     &:not(:hover):not(:focus) {
         ${HoverPanel} {
@@ -98,7 +98,7 @@ const Description = styled.p`
 `;
 
 const Detail = styled.div`
-    padding: 20px 20px 60px;
+    padding: 20px 20px;
     height: auto;
 `;
 
@@ -148,14 +148,15 @@ const TemplateItem = ({
             <Detail>
                 <Title>{title}</Title>
                 <Description>{description}</Description>
-                {author && (
+                {/* Hide the Mattermost logo from Playbook cards */}
+                {/* {author && (
                     <Tooltip
                         id={`${title}_author_usedby`}
                         content={formatMessage({defaultMessage: 'Used by'})}
                     >
                         <Author>{author}</Author>
                     </Tooltip>
-                )}
+                )} */}
             </Detail>
         </Item>
     );


### PR DESCRIPTION
Removed the Mattermost logo from Playbook cards.

Screenshot:
![image](https://user-images.githubusercontent.com/72438220/169254538-0142cb54-3977-4594-8a90-d9d021dd9887.png)
